### PR TITLE
add grunt-chrome-manifest task to handle manifest

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -234,6 +234,16 @@ module.exports = function (grunt) {
                 'cssmin'
             ]
         },
+        chromeManifest: {
+            dist: {
+                options: {
+                    buildnumber: true,
+                    background: 'scripts/background.js'
+                },
+                src: '<%%= yeoman.app %>',
+                dest: '<%%= yeoman.dist %>'
+            }
+        },
         compress: {
             dist: {
                 options: {
@@ -251,40 +261,6 @@ module.exports = function (grunt) {
 
     grunt.renameTask('regarde', 'watch');
 
-    grunt.registerTask('prepareManifest', function() {
-        var scripts = [];
-        var concat = grunt.config('concat') || {dist:{files:{}}};
-        var uglify = grunt.config('uglify') || {dist:{files:{}}};
-        var manifest = grunt.file.readJSON(yeomanConfig.app + '/manifest.json');
-
-        if (manifest.background.scripts) {
-            manifest.background.scripts.forEach(function (script) {
-                scripts.push(yeomanConfig.app + '/' + script);
-            });
-            concat.dist.files['<%%= yeoman.dist %>/scripts/background.js'] = scripts;
-            uglify.dist.files['<%%= yeoman.dist %>/scripts/background.js'] = '<%%= yeoman.dist %>/scripts/background.js';
-        }
-
-        if (manifest.content_scripts) {
-            manifest.content_scripts.forEach(function(contentScript) {
-                if (contentScript.js) {
-                    contentScript.js.forEach(function(script) {
-                        uglify.dist.files['<%%= yeoman.dist %>/' + script] = '<%%= yeoman.app %>/' + script;
-                    });
-                }
-            });
-        }
-
-        grunt.config('concat', concat);
-        grunt.config('uglify', uglify);
-    });
-
-    grunt.registerTask('manifest', function() {
-        var manifest = grunt.file.readJSON(yeomanConfig.app + '/manifest.json');
-        manifest.background.scripts = ['scripts/background.js'];
-        grunt.file.write(yeomanConfig.dist + '/manifest.json', JSON.stringify(manifest, null, 2));
-    });
-
     grunt.registerTask('test', [
         'clean:server',
         'concurrent:test',
@@ -294,14 +270,13 @@ module.exports = function (grunt) {
 
     grunt.registerTask('build', [
         'clean:dist',
-        'prepareManifest',
+        'chromeManifest:dist',
         'useminPrepare',
         'concurrent:dist',
         'concat',
         'uglify',
         'copy',
         'usemin',
-        'manifest',
         'compress'
     ]);
 

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -23,7 +23,8 @@
     "grunt-open": "~0.2.0",
     "grunt-svgmin": "~0.1.0",
     "grunt-concurrent": "~0.1.0",
-    "matchdep": "~0.1.1"
+    "matchdep": "~0.1.1",
+    "grunt-chrome-manifest": "~0.1.0"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
i made a new grunt task[1](https://github.com/ragingwind/grunt-chrome-manifest) to handle manifest.json of chrome. the grunt task has a two feature. one is adds js/css file list in manifest to configuration of cssmin/uglify/concat, like useminPrepare task. and auto increment build number task. 

i'd like to use grunt-chrome-manifest to both generator, chrome-extension and chromeapp.
