### PR TITLE
Updated with #14, use grunt-contrib-watch and more:

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,5 @@
 {
 	"node": true,
-	"es5": true,
 	"esnext": true,
 	"bitwise": false,
 	"curly": false,

--- a/app/index.js
+++ b/app/index.js
@@ -33,7 +33,7 @@ var ChromeExtensionGenerator = module.exports = function ChromeExtensionGenerato
   this.pkg = JSON.parse(this.readFileAsString(path.join(__dirname, '../package.json')));
 };
 
-util.inherits(ChromeExtensionGenerator, yeoman.generators.NamedBase);
+util.inherits(ChromeExtensionGenerator, yeoman.generators.Base);
 
 ChromeExtensionGenerator.prototype.askFor = function askFor(argument) {
   var cb = this.async();

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -24,6 +24,9 @@ module.exports = function (grunt) {
     grunt.initConfig({
         yeoman: yeomanConfig,
         watch: {
+            options: {
+                spawn: false
+            },
             coffee: {
                 files: ['<%%= yeoman.app %>/scripts/{,*/}*.coffee'],
                 tasks: ['coffee:dist']
@@ -35,7 +38,7 @@ module.exports = function (grunt) {
             compass: {
                 files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
                 tasks: ['compass:server']
-            },
+            }
         },
         connect: {
             options: {
@@ -219,7 +222,7 @@ module.exports = function (grunt) {
                     cwd: '<%%= yeoman.app %>',
                     dest: '<%%= yeoman.dist %>',
                     src: [
-                        '*.{ico,txt}',
+                        '*.{ico,png,txt}',
                         'images/{,*/}*.{webp,gif}',
                         '_locales/{,*/}*.json'
                     ]

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -15,10 +15,10 @@
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-htmlmin": "~0.1.3",
     "grunt-contrib-imagemin": "~0.1.3",
-    "grunt-contrib-compress": "~0.4.7", <% if (testFramework === 'jasmine') { %>
+    "grunt-contrib-compress": "~0.4.7",
+    "grunt-contrib-watch": "~0.4.0", <% if (testFramework === 'jasmine') { %>
     "grunt-contrib-jasmine": "~0.4.2",<% } %>
-    "grunt-usemin": "~0.1.10",
-    "grunt-regarde": "~0.1.1",<% if (testFramework === 'mocha') { %>
+    "grunt-usemin": "~0.1.10", <% if (testFramework === 'mocha') { %>
     "grunt-mocha": "~0.3.0",<% } %>
     "grunt-open": "~0.2.0",
     "grunt-svgmin": "~0.1.0",

--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -1,7 +1,6 @@
 {
     "node": true,
     "browser": true,
-    "es5": true,
     "esnext": true,
     "bitwise": true,
     "camelcase": true,

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,7 @@ describe('Chrome Extension generator test', function () {
 
   it('creates expected files in no UI Action', function (done) {
     var expected = [
+      'app/bower_components',
       ['bower.json', /"name": "temp"/],
       ['package.json', /"name": "temp"/],
       'Gruntfile.js',
@@ -52,6 +53,7 @@ describe('Chrome Extension generator test', function () {
 
   it('creates expected files in Browser Action', function (done) {
     var expected = [
+      'app/bower_components',
       ['bower.json', /"name": "temp"/],
       ['package.json', /"name": "temp"/],
       'Gruntfile.js',
@@ -81,6 +83,7 @@ describe('Chrome Extension generator test', function () {
 
   it('creates expected files in Page Action', function (done) {
     var expected = [
+      'app/bower_components',
       ['bower.json', /"name": "temp"/],
       ['package.json', /"name": "temp"/],
       'Gruntfile.js',
@@ -110,6 +113,7 @@ describe('Chrome Extension generator test', function () {
 
   it('creates expected files with Options Page', function (done) {
     var expected = [
+      'app/bower_components',
       ['bower.json', /"name": "temp"/],
       ['package.json', /"name": "temp"/],
       'Gruntfile.js',
@@ -154,6 +158,7 @@ describe('Chrome Extension generator test', function () {
 
   it('creates expected files with Content-script option', function (done) {
     var expected = [
+      'app/bower_components',
       ['bower.json', /"name": "temp"/],
       ['package.json', /"name": "temp"/],
       'Gruntfile.js',


### PR DESCRIPTION
Remove deprecated es5 rule from jshintrc
Use grunt-contrib-watch
Inherit from generators.Base
Add touch icon pattern to copy:dist task
Add 'bower_components' to expected list of test
