### PR TITLE
Add `yo` as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "cheerio": "~0.10.8"
   },
   "peerDependencies": {
-    "generator-mocha": "~0.1.1"
+    "generator-mocha": "~0.1.1",
+    "yo": ">=1.0.0-rc.1.1"
   },
   "devDependencies": {
     "mocha": "~1.10.0"


### PR DESCRIPTION
By adding `yo` as peer dependency, the user only has to `npm install -g generator-chrome-extension` and is good to go.

/ref https://github.com/yeoman/generator/issues/305
