### PR TITLE
fix a templates bug.

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -259,7 +259,9 @@ module.exports = function (grunt) {
             dist: {
                 options: {
                     buildnumber: true,
-                    background: 'scripts/background.js'
+                    background: {
+                        target:'scripts/background.js'
+                    }
                 },
                 src: '<%%= yeoman.app %>',
                 dest: '<%%= yeoman.dist %>'


### PR DESCRIPTION
use options.background.target for Gruntfile, 
the old version will get a "path.join" error in grunt-chrome-manifest

line: 22   " var background = path.join(dest, options.background.target);"
