### PR TITLE
Add support for grunt watch

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
             },
             compass: {
                 files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
-                tasks: ['compass:server']
+                tasks: ['compass:server', 'clean:main', 'concat:dev']
             }
         },
         connect: {
@@ -72,6 +72,7 @@ module.exports = function (grunt) {
                     ]
                 }]
             },
+            main: '<%%= yeoman.app %>/styles/main.css',
             server: '.tmp'
         },
         jshint: {
@@ -106,7 +107,7 @@ module.exports = function (grunt) {
                     expand: true,
                     cwd: '<%%= yeoman.app %>/scripts',
                     src: '{,*/}*.coffee',
-                    dest: '.tmp/scripts',
+                    dest: '<%%= yeoman.app %>/scripts',
                     ext: '.js'
                 }]
             },
@@ -140,9 +141,11 @@ module.exports = function (grunt) {
                 }
             }
         },
-        // not used since Uglify task does concat,
-        // but still available if needed
-        /*concat: {
+        concat: {
+              dev: {
+                src: ['.tmp/styles/*.css'],
+                dest: '<%%= yeoman.app %>/styles/main.css'
+              },
             dist: {}
         },*/
         // not enabled since usemin task does concat and uglify
@@ -188,6 +191,11 @@ module.exports = function (grunt) {
             }
         },
         cssmin: {
+            'with-sass': {
+                files: {
+                    '<%= yeoman.dist %>/styles/main.css': '.tmp/styles/{,*/}*.css'
+                }
+            },
             dist: {
                 files: {
                     '<%%= yeoman.dist %>/styles/main.css': [
@@ -293,12 +301,13 @@ module.exports = function (grunt) {
         'jasmine'<% } %>
     ]);
 
+    var target = grunt.option('with-sass') ? 'with-sass' : 'dist';
     grunt.registerTask('build', [
         'clean:dist',
         'chromeManifest:dist',
         'useminPrepare',
         'concurrent:dist',
-        'cssmin',
+        'cssmin:' + target,
         'concat',
         'uglify',
         'copy',

--- a/readme.md
+++ b/readme.md
@@ -24,15 +24,20 @@ Chrome Extension generator that creates everything you need to get started with 
 
 If you need more information? Please visit [Google Chrome Extension Develpment](http://developer.chrome.com/extensions/devguide.html)
 
-## Test
-To test, go to: chrome://extensions, enable Developer mode and load app as an unpacked extension.
+## Development
+Go to: chrome://extensions, enable Developer mode and load app as an unpacked extension choosing the /app directory. If you desire to use SASS and/or Coffeescript when developing a `grunt watch` task is provided.
 
 ## Build & Package
 By default, generators compress the file that was created by building a js/css/html/resource file. You can distribute the compressed file using the Chrome Developer Dashboard to publish to the Chrome Web Store.
 
 Run this command to build your Chrome Extension project.
 
-```grunt build```
+`grunt build` 
+
+or 
+
+`grunt build --with-sass` if `grunt watch` was used to pre-process your CSS.
+
 
 ## Contribute
 


### PR DESCRIPTION
Here is my take on using `grunt watch` to to develop an extension.

This PR assumes that one develops by loading the extension against the /app directory. If developing/testing loading against the /app directory then the current implementation of `grunt watch` doesn't work.

All modifications are to `Gruntfile.js` template and the `readme.md`.

For Coffeescript support, the changes are very minimal. Simply have `coffee:dist` output to `app/scripts`. Additional js files can be added via the build:js in popup.html. The `grunt build` works as expected.

New SASS modifications pre-process to app/styles/main.css. In this way no additional css files need to be added to popup.html.

I added an option called `--with-sass` (to be used with the `build` task) because the `app/styles` directory needs to be excluded by cssmin because concatenation has already occurred by the `watch` task. The `.tmp/styles` directory does have the individual css files output from the `watch` (`compass:server`) task and are the proper target for cssmin.
For users who are creating pure css files in the `app/styles` directory we leave `grunt build` the way it is.
