### PR TITLE
Change how name and description are set in the manifest template

### DIFF
--- a/app/templates/manifest.json
+++ b/app/templates/manifest.json
@@ -1,8 +1,8 @@
 {
-    "name": "__MSG_appName__",
+    "name": "<%= manifest.name %>",
     "version": "0.0.1",
     "manifest_version": 2,
-    "description": "__MSG_appDescription__",
+    "description": "<%= manifest.description %>",
     "icons": {
         "16": "images/icon-16.png",
         "128": "images/icon-128.png"


### PR DESCRIPTION
The prompted for name and description were not being set in the manifest file for me. This change fixes this for me, not sure if I am missing something though.
