### PR TITLE
Clarify README.md on Auto-reloading

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,14 +33,9 @@ yo chrome-extension
 
 To test, go to: chrome://extensions, enable Developer mode and load app as an unpacked extension.
 
-## Debug
+## Auto-reloading the Extension
 
-Support for LiveReload
-
-Example:
-```bash
-grunt debug
-```
+Use `grunt debug` while developing. It automatically reloads the extension on Chrome when the files change. Fun fact: [this uses LiveReload behind the scenes](https://github.com/yeoman/generator-chrome-extension/issues/31#issuecomment-23689128).
 
 ## Build & Package
 


### PR DESCRIPTION
It wasn't clear that `grunt debug` gives you auto-reloading. This should be more clear. See: #31 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/yeoman/generator-chrome-extension/85)

<!-- Reviewable:end -->
