### PR TITLE
style(manifest): indentation remains unchanged after build

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -351,6 +351,7 @@ module.exports = function (grunt) {
       dist: {
         options: {
           buildnumber: true,
+          indentSize: 2,
           background: {
             target: 'scripts/background.js',
             exclude: [


### PR DESCRIPTION
Default manifest indentation is 2 spaces and the same is defined in `.jshintrc`. 

[ragingwind/grunt-chrome-manifest](https://github.com/ragingwind/grunt-chrome-manifest/) was changing it to 4 spaces after each build. 

Now it doesn't :).
