### PR TITLE
.jshintrc adjusted to work better with compiled coffeescript

### DIFF
--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -5,13 +5,14 @@
   "bitwise": true,
   "camelcase": true,
   "curly": true,
-  "eqeqeq": true,
+  "eqeqeq": true,<%if (coffee) { %>
+  "eqnull": true,<% } %>
   "immed": true,
   "indent": 2,
   "latedef": true,
   "newcap": true,
   "noarg": true,
-  "quotmark": "single",
+  "quotmark": <%if (coffee) { %>false<% } else { %>"single"<% } %>,
   "regexp": true,
   "undef": true,
   "unused": true,
@@ -19,6 +20,7 @@
   "trailing": true,
   "smarttabs": true,
   "globals" : {
-    "chrome": true
+    "chrome": true,
+    "crypto": true
   }
 }


### PR DESCRIPTION
Coffeescript compiler is violating some of current `.jshintrc` rules and some grunt tasks error for a valid code.

I've changed 3 things (1st isn't CS-specific):
#### 1. `'crypto' is not defined.`

Chrome [supports it from version 11](http://caniuse.com/#feat=getrandomvalues). I don't know why it's not included in `browser` environment (any ideas?), but I think it's quite safe to add it to `globals`.
#### 2. `Expected '!==' and instead saw '!='.`

This CS code:

``` coffeescript
if arr[n]
  doSth()
```

gets compiled to:

``` js
if (arr[n] != null) {
  doSth();
}
```

hence `"eqnull":true`
#### 3. `Strings must use singlequote.`

Seems like CS is (almost) always using singlequotes, except typechecking:

``` coffeescript
cb? sth
```

gets compiled to:

``` js
typeof cb === "function" ? cb(data) : void 0;
```

hence `"quotmark": false`

PS. Is there any way to either ask compiler to output jshint-compliant code or (what would be significantly more useful) _jshint_ coffeescript code instead?
