### PR TITLE
Grunt build include a file with '.' as a name

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -376,7 +376,7 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: 'dist/',
-          src: ['**'],
+          src: ['**/*'],
           dest: ''
         }]
       }


### PR DESCRIPTION
This cause problems when you try to install the extension on Windows or Mac
Please look at:
http://stackoverflow.com/questions/24695345/grunt-contrib-compress-exclude-dot-folder