### PR TITLE
Comment out default styles in the template css.

### DIFF
--- a/app/templates/styles/main.css
+++ b/app/templates/styles/main.css
@@ -1,3 +1,3 @@
 body {
-  padding: 20px;
+  /* padding: 20px; */
 }

--- a/app/templates/styles/main.scss
+++ b/app/templates/styles/main.scss
@@ -1,4 +1,4 @@
 $padding: 20px;
 body {
-  padding: $padding;
+  // padding: $padding;
 }


### PR DESCRIPTION
I don't think the generator needs to apply default css. This
change leaves the file in place so that users will know where
to edit the file, but it removes the default padding of 20px
to the body element, which seems to me to be an unusual
default.

Closes #107.