### PR TITLE
Upgrade grunt-contrib-jshint to 0.10.0.

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -9,7 +9,7 @@
     "grunt-contrib-coffee": "~0.10.1",<% } %>
     "grunt-contrib-uglify": "~0.4.0",<% if (compass) { %>
     "grunt-contrib-compass": "~0.7.0",<% } %>
-    "grunt-contrib-jshint": "~0.9.2",
+    "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-cssmin": "~0.9.0",
     "grunt-contrib-connect": "~0.7.1",
     "grunt-contrib-clean": "~0.5.0",

--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -1,6 +1,8 @@
 {
   "node": true,
-  "browser": true,
+  "browser": true,<% if (testFramework === 'mocha') { %>
+  "mocha": true,<% } else if (testFramework === 'jasmine') { %>
+  "jasmine": true,<% } %>
   "esnext": true,
   "bitwise": true,
   "camelcase": true,
@@ -13,12 +15,9 @@
   "newcap": true,
   "noarg": true,
   "quotmark": <%if (coffee) { %>false<% } else { %>"single"<% } %>,
-  "regexp": true,
   "undef": true,
   "unused": true,
   "strict": true,
-  "trailing": true,
-  "smarttabs": true,
   "globals" : {
     "chrome": true,
     "crypto": true


### PR DESCRIPTION
Ignore Mocha and Jasmine interfaces in JSHint.
Remove obsolete / removed options from jshintrc.
Fixes #114.