### PR TITLE
Added options v2

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -200,7 +200,12 @@ module.exports = yeoman.generators.Base.extend({
 
     // add options page field.
     if (this.manifest.options) {
+      var options_ui = {
+        "page": "options.html",
+        "chrome_style": true
+      };
       manifest.options_page = '"options.html"';
+      manifest.options_ui = JSON.stringify(options_ui, null, 2).replace(/\n/g, '\n  ');
     }
 
     // add omnibox keyword field.

--- a/test/test-extension.js
+++ b/test/test-extension.js
@@ -17,7 +17,7 @@ describe('Extension test', function () {
         'app/images/icon-128.png',
         'app/images/icon-16.png'
       ];
-  
+
       assert.file(expected);
       assert.fileContent([
         ['bower.json', /"name": "temp"/],
@@ -27,7 +27,7 @@ describe('Extension test', function () {
       done();
     });
   });
-  
+
   it('creates expected files in Browser Action', function (done) {
     helper.run({}, {
       'action': 'Browser'
@@ -37,7 +37,7 @@ describe('Extension test', function () {
         'app/scripts/popup.js',
         'app/popup.html'
       ];
-  
+
       assert.file(expected);
       assert.fileContent([
         ['app/manifest.json', /"browser_action": {\s+"default_icon": {\s+"19": "images\/icon-19.png",\s+"38": "images\/icon-38.png"\s+},\s+"default_title": "temp",\s+"default_popup": "popup.html"\s+}/]
@@ -46,7 +46,7 @@ describe('Extension test', function () {
       done();
     });
   });
-  
+
   it('creates expected files in Page Action', function (done) {
     helper.run({}, {
       'action': 'Page'
@@ -56,7 +56,7 @@ describe('Extension test', function () {
         'app/scripts/popup.js',
         'app/popup.html'
       ];
-  
+
       assert.file(expected);
       assert.fileContent([
         ['app/manifest.json', /"page_action": {\s+"default_icon": {\s+"19": "images\/icon-19.png",\s+"38": "images\/icon-38.png"\s+},\s+"default_title": "temp",\s+"default_popup": "popup.html"\s+}/]
@@ -65,7 +65,7 @@ describe('Extension test', function () {
       done();
     });
   });
-  
+
   it('creates expected files with Options Page', function (done) {
     helper.run({}, {
       'uifeatures': ['options']
@@ -74,17 +74,18 @@ describe('Extension test', function () {
         'app/scripts/options.js',
         'app/options.html'
       ];
-  
+
       assert.file(expected);
       assert.fileContent([
         ['bower.json', /"name": "temp"/],
         ['package.json', /"name": "temp"/],
-        ['app/manifest.json', /"options_page": "options.html"/]
+        ['app/manifest.json', /"options_page": "options.html"/],
+        ['app/manifest.json', /"options_ui": {\s+"page": "options.html",\s+"chrome_style": true\s+}/]
       ]);
       done();
     });
   });
-  
+
   it('creates manifest.json with Omnibox option', function (done) {
     helper.run({}, {
       'uifeatures': ['omnibox']
@@ -95,7 +96,7 @@ describe('Extension test', function () {
       done();
     });
   });
-  
+
   it('creates expected files with Content-script option', function (done) {
     helper.run({}, {
       'uifeatures': ['contentscript']
@@ -106,7 +107,7 @@ describe('Extension test', function () {
       done();
     });
   });
-  
+
   it('creates expected manifest permission properties', function (done) {
     helper.run({}, {
       'permissions': [


### PR DESCRIPTION
> At least until Chrome 40 is stable, you should specify both the options_ui and the options_page fields. 

> Chrome will continue to support the options_page manifest field, but new and existing extensions should use the options_ui to ensure that their options pages are displayed as intended.

https://developer.chrome.com/extensions/optionsV2