### PR TITLE
Added optionsV2

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -70,7 +70,7 @@ module.exports = yeoman.generators.Base.extend({
 
       dest = dest ? dest + '.js' : srcFile;
       this.fs.copy(
-        this.templatePath('scripts/' + srcFile), 
+        this.templatePath('scripts/' + srcFile),
         this.destinationPath('app/scripts/' + dest)
       );
     };
@@ -256,7 +256,12 @@ module.exports = yeoman.generators.Base.extend({
 
     // add options page field.
     if (this.manifest.options) {
+      var options_ui = {
+        page: 'options.html',
+        chrome_style: true
+      };
       manifest.options_page = '"options.html"';
+      manifest.options_ui = JSON.stringify(options_ui, null, 2).replace(/\n/g, '\n  ');
     }
 
     // add omnibox keyword field.
@@ -310,19 +315,19 @@ module.exports = yeoman.generators.Base.extend({
     if (this.manifest.action === 0) {
       return;
     }
-    
+
     this.fs.copy(
       this.templatePath('popup.html'),
       this.destinationPath('app/popup.html')
     );
-    
+
     this.copyjs('popup');
 
     this.fs.copy(
       this.templatePath('images/icon-19.png'),
       this.destinationPath('app/images/icon-19.png')
     );
-    
+
     this.fs.copy(
       this.templatePath('images/icon-38.png'),
       this.destinationPath('app/images/icon-38.png')
@@ -389,7 +394,7 @@ module.exports = yeoman.generators.Base.extend({
 
   assets: function () {
     this.fs.copyTpl(
-      this.templatePath('_locales/en/messages.json'), 
+      this.templatePath('_locales/en/messages.json'),
       this.destinationPath('app/_locales/en/messages.json'),
       this.manifest
     );

--- a/test/test-extension.js
+++ b/test/test-extension.js
@@ -65,7 +65,7 @@ describe('Extension test', function () {
       done();
     });
   });
-  
+
   it('creates expected files with Options Page', function (done) {
     helper.run({}, {
       'uifeatures': ['options']
@@ -79,7 +79,8 @@ describe('Extension test', function () {
       assert.fileContent([
         ['bower.json', /"name": "temp"/],
         ['package.json', /"name": "temp"/],
-        ['app/manifest.json', /"options_page": "options.html"/]
+        ['app/manifest.json', /"options_page": "options.html"/],
+        ['app/manifest.json', /"options_ui": {\s+"page": "options.html",\s+"chrome_style": true\s+}/]
       ]);
       done();
     });


### PR DESCRIPTION
> Chrome will continue to support the options_page manifest field, but new and existing extensions should use the options_ui to ensure that their options pages are displayed as intended.

> If you specify both, Chrome 40 and onwards will ignore the value of options_page.

> In a future version of Chrome, any extension which specifies options_page will change to match the options_ui behavior - most importantly, they will always be embedded in chrome://extensions - so migrate as soon as possible.

https://developer.chrome.com/extensions/optionsV2