### PR TITLE
Add grunt-cli as a dev dependency, add npm scripts

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -1,9 +1,17 @@
 {
   "name": "<%= name %>",
   "private": true,
+  "scripts": {
+    "start": "grunt",<% if (babel) { %>
+    "babel": "grunt babel",<% } %>
+    "build": "grunt build",
+    "debug": "grunt debug",
+    "watch": "grunt watch"
+  },
   "dependencies": {},
   "devDependencies": {
-    "grunt": "~0.4.5",<% if (babel) { %>
+    "grunt": "~0.4.5",
+    "grunt-cli": "^0.1.13",<% if (babel) { %>
     "grunt-babel": "^5.0.1",<% } %>
     "grunt-contrib-copy": "~0.8.1",
     "grunt-contrib-concat": "~0.5.1",


### PR DESCRIPTION
Facilitates project tooling that does not necessitate global installs,
and allows for better control over build tool versioning by scoping it
to the project.

The grunt-cli project refers to this practice as ['the idiomatic Node.js method to get started with a project'](https://github.com/gruntjs/grunt-cli#installing-grunt-cli-locally), and it seems like a nice option for folks that does not prohibit the existing tasks and their methods from working.