### PR TITLE
Add permissions from chrome-manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "mocha --reporter spec"
   },
   "dependencies": {
+    "chrome-manifest": "^0.2.5",
     "generator-jasmine": "^0.2.1",
     "generator-mocha": "^0.2.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Closes #126, introduces first steps of #128.

Been using this generator a decent bit and actually did a quick scrape of the current docs to get a full current permissions list, then saw #128. Figured I'd leverage the [work I'd already done](https://github.com/maxmechanic/generator-chrome-extension/commit/3a9d5b640a88c194e141140e2b40dbf2df9642a2) and at least get permissions pulling from chrome-manifest. 