### PR TITLE
Update gulpfile.babel.js

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -134,7 +134,7 @@ gulp.task('wiredep', () => {
 
 gulp.task('package', function () {
   var manifest = require('./dist/manifest.json');
-  return gulp.src('dist/*')
+  return gulp.src('dist/**')
       .pipe($.zip('<%= appname %>-' + manifest.version + '.zip'))
       .pipe(gulp.dest('package'));
 });


### PR DESCRIPTION
To make package build will also pack the directory under `_locals`.

For example,the directory tree of `dist` is:

````
dist -
      - locales
            -en
                -message.json
       -....
```

Then with origin package, the `message.json` is missing in final zip.