### PR TITLE
added browserify and support for ES2015 modules

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -9,6 +9,9 @@
     "babel-preset-es2015": "^6.5.0",
     "del": "^2.2.0",
     "gulp": "^3.9.1",<% if (babel) { %>
+    "babelify": "^7.2.0",
+    "browserify": "^13.0.0",
+    "vinyl-source-stream": "^1.1.0",
     "gulp-babel": "^6.1.2",<% } %>
     "gulp-cache": "^0.4.2",
     "gulp-chrome-manifest": "0.0.13",
@@ -37,6 +40,13 @@
     },
     "globals": {
       "chrome": true
+    },
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module",
+      "ecmaFeatures": {
+        "modules": true
+      }
     },
     "rules": {
       "eol-last": 0,

--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -4,6 +4,11 @@ import gulpLoadPlugins from 'gulp-load-plugins';
 import del from 'del';
 import runSequence from 'run-sequence';
 import {stream as wiredep} from 'wiredep';
+<% if (babel) { %>
+import browserify from 'browserify';
+import source from 'vinyl-source-stream';
+import es from 'event-stream';
+<% } %>
 
 const $ = gulpLoadPlugins();
 
@@ -91,11 +96,23 @@ gulp.task('chromeManifest', () => {
 });
 <% if (babel) { %>
 gulp.task('babel', () => {
-  return gulp.src('app/scripts.babel/**/*.js')
-      .pipe($.babel({
-        presets: ['es2015']
-      }))
-      .pipe(gulp.dest('app/scripts'));
+  let files = [
+    'contentscript.js',
+    'background.js',
+    'chromereload.js'
+  ];
+
+  let tasks = files.map( file => {
+      return browserify({
+        entries: './app/scripts.babel/' + file,
+        debug: true
+      }).transform('babelify', { presets: ['es2015'] })
+        .bundle()
+        .pipe(source(file))
+        .pipe(gulp.dest('app/scripts'));
+  });
+
+  return es.merge.apply(null, tasks);
 });
 <% } %>
 gulp.task('clean', del.bind(null, ['.tmp', 'dist']));


### PR DESCRIPTION
This PR will allow the generator to support Browserify so we can use modules inside our chrome apps. 

The base file for modules needs to be configured in gulp it will automatically include all imported modules.

All tests passing!