### PR TITLE
Fix minifing js/css in html

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -63,11 +63,11 @@ gulp.task('styles', () => {
 
 gulp.task('html', <% if (sass) { %>['styles'],<% } %> () => {
   return gulp.src('app/*.html')
+    .pipe($.useref({searchPath: ['.tmp', 'app', '.']}))
     .pipe($.sourcemaps.init())
     .pipe($.if('*.js', $.uglify()))
     .pipe($.if('*.css', $.minifyCss({compatibility: '*'})))
     .pipe($.sourcemaps.write())
-    .pipe($.useref({searchPath: ['.tmp', 'app', '.']}))
     .pipe($.if('*.html', $.minifyHtml({conditionals: true, loose: true})))
     .pipe(gulp.dest('dist'));
 });


### PR DESCRIPTION
- Minifying js/css in html does not work now. It should be after `$.useref`.
- Disable sourcemaps. Because `dist` directory is for production and minified+sourcemap file is larger than original. It makes no sense. We can debug in `app` directory for development.