### PR TITLE
Replace gulp-minify-css with gulp-clean-css

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -12,12 +12,12 @@
     "gulp-babel": "^6.1.2",<% } %>
     "gulp-cache": "^0.4.2",
     "gulp-chrome-manifest": "0.0.13",
+    "gulp-clean-css": "^2.0.3",
     "gulp-eslint": "^2.0.0",
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^2.4.0",
     "gulp-livereload": "^3.8.1",
     "gulp-load-plugins": "^1.2.0",
-    "gulp-minify-css": "^1.2.3",
     "gulp-minify-html": "^1.0.5",<% if (sass) { %>
     "gulp-plumber": "^1.1.0",
     "gulp-sass": "^2.2.0",<% } %>

--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -65,7 +65,7 @@ gulp.task('html', <% if (sass) { %>['styles'],<% } %> () => {
   return gulp.src('app/*.html')
     .pipe($.sourcemaps.init())
     .pipe($.if('*.js', $.uglify()))
-    .pipe($.if('*.css', $.minifyCss({compatibility: '*'})))
+    .pipe($.if('*.css', $.cleanCss({compatibility: '*'})))
     .pipe($.sourcemaps.write())
     .pipe($.useref({searchPath: ['.tmp', 'app', '.']}))
     .pipe($.if('*.html', $.minifyHtml({conditionals: true, loose: true})))
@@ -83,7 +83,7 @@ gulp.task('chromeManifest', () => {
         ]
       }
   }))
-  .pipe($.if('*.css', $.minifyCss({compatibility: '*'})))
+  .pipe($.if('*.css', $.cleanCss({compatibility: '*'})))
   .pipe($.if('*.js', $.sourcemaps.init()))
   .pipe($.if('*.js', $.uglify()))
   .pipe($.if('*.js', $.sourcemaps.write('.')))


### PR DESCRIPTION
[gulp-minify-css](https://www.npmjs.com/package/gulp-minify-css "gulp-minify-css") is deprecated.