### PR TITLE
Added npm-debug.log to gitignore

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -6,5 +6,6 @@ dist
 app/bower_components
 test/bower_components
 package
+npm-debug.log
 <% if (babel) { %>app/scripts<% } %>
 <% if (sass) { %>app/styles<% } %>


### PR DESCRIPTION
Hello,

I like npm scripts so I have created one called **watch** 

`
"scripts": {
    "watch": "gulp watch"
  }
`

But everytime I made a syntax mistake it generate the **npm-debug.log** file and by mistake I added to my git repository :sob: 

I assume nobody wants this kind of logs in their repository so can we add **npm-debug.log** to the gitignore file?

Thank you!