### PR TITLE
Reload the extension as well as the pages

### DIFF
--- a/app/templates/scripts/chromereload.js
+++ b/app/templates/scripts/chromereload.js
@@ -34,6 +34,7 @@ connection.onmessage = function (e) {
     var data = JSON.parse(e.data);
     if (data && data.command === 'reload') {
       chrome.runtime.reload();
+      chrome.developerPrivate.reload(chrome.runtime.id, {failQuietly: true});
     }
   }
 };

--- a/app/templates/scripts/chromereload.js
+++ b/app/templates/scripts/chromereload.js
@@ -8,6 +8,12 @@ const LIVERELOAD_HOST = 'localhost:';
 const LIVERELOAD_PORT = 35729;
 const connection = new WebSocket('ws://' + LIVERELOAD_HOST + LIVERELOAD_PORT + '/livereload');
 
+var lastReload = false;
+
+chrome.runtime.onInstalled.addListener(function(details) {
+  lastReload = Date.now();
+});    
+
 connection.onerror = error => {
   console.log('reload connection got error:', error);
 };
@@ -16,7 +22,13 @@ connection.onmessage = e => {
   if (e.data) {
     const data = JSON.parse(e.data);
     if (data && data.command === 'reload') {
-      chrome.runtime.reload();
+      var currentTime = Date.now();
+      if (lastReload && currentTime - lastReload > 60000) {
+	// don't reload more than once a minute
+	chrome.runtime.reload();
+	chrome.developerPrivate.reload(chrome.runtime.id, 
+				       {failQuietly: true});
+      }
     }
   }
 };
@@ -24,6 +36,12 @@ connection.onmessage = e => {
 var LIVERELOAD_HOST = 'localhost:';
 var LIVERELOAD_PORT = 35729;
 var connection = new WebSocket('ws://' + LIVERELOAD_HOST + LIVERELOAD_PORT + '/livereload');
+
+var lastReload = false;
+
+chrome.runtime.onInstalled.addListener(function(details) {
+  lastReload = Date.now();
+});    
 
 connection.onerror = function (error) {
   console.log('reload connection got error:', error);
@@ -33,8 +51,12 @@ connection.onmessage = function (e) {
   if (e.data) {
     var data = JSON.parse(e.data);
     if (data && data.command === 'reload') {
-      chrome.runtime.reload();
-      chrome.developerPrivate.reload(chrome.runtime.id, {failQuietly: true});
+      if (lastReload && currentTime - lastReload > 60000) {
+	// don't reload more than once a minute
+	chrome.runtime.reload();
+	chrome.developerPrivate.reload(chrome.runtime.id, 
+				       {failQuietly: true});
+      }
     }
   }
 };


### PR DESCRIPTION
chrome.runtime.reload() doesn't actually reload the extension from the source. I solved this by adding chrome.developerPrivate.reload(...). Now when you change the files and livereload is triggered the extension reloads from the source.
