### PR TITLE
minify inline css and js

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -18,7 +18,7 @@
     "gulp-imagemin": "^2.4.0",
     "gulp-livereload": "^3.8.1",
     "gulp-load-plugins": "^1.2.0",
-    "gulp-htmlmin": "^1.3.0",<% if (sass) { %>
+    "gulp-htmlmin": "^2.0.0",<% if (sass) { %>
     "gulp-plumber": "^1.1.0",
     "gulp-sass": "^2.2.0",<% } %>
     "gulp-size": "^2.1.0",

--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -68,7 +68,12 @@ gulp.task('html', <% if (sass) { %>['styles'],<% } %> () => {
     .pipe($.if('*.js', $.uglify()))
     .pipe($.if('*.css', $.cleanCss({compatibility: '*'})))
     .pipe($.sourcemaps.write())
-    .pipe($.if('*.html', $.htmlmin({removeComments: true, collapseWhitespace: true})))
+    .pipe($.if('*.html', $.htmlmin({
+      collapseWhitespace: true,
+      minifyCSS: true,
+      minifyJS: true,
+      removeComments: true
+    })))
     .pipe(gulp.dest('dist'));
 });
 


### PR DESCRIPTION
# Description

Updates the `gulp-htmlmin` package and adds support for minifying inline css and js.