### PR TITLE
Add babel-register to devDependencies

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -6,6 +6,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.7.2",
+    "babel-register": "^6.7.2",
     "babel-preset-es2015": "^6.6.0",
     "del": "^2.2.0",
     "gulp": "^3.9.1",<% if (babel) { %>


### PR DESCRIPTION
Fixes the following error when running gulp tasks:
"Failed to load external module babel-register"