### PR TITLE
Reload css file when the style changes

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -105,7 +105,7 @@ gulp.task('babel', () => {
 <% } %>
 gulp.task('clean', del.bind(null, ['.tmp', 'dist']));
 
-gulp.task('watch', ['lint'<% if (babel) { %>, 'babel'<% } %>], () => {
+gulp.task('watch', ['lint', 'styles'<% if (babel) { %>, 'babel'<% } %>], () => {
   $.livereload.listen();
 
   gulp.watch([


### PR DESCRIPTION
This PR is to include the `styles` task into the `gulp watch`, so that when any css file change, gulp will reload corresponding file as well.