### PR TITLE
fixed typo command in docs/recipes

### DIFF
--- a/docs/recipes/browserify.md
+++ b/docs/recipes/browserify.md
@@ -8,8 +8,10 @@ Follow this recipe to configure Browserify.
 
 1. Install dependencies
 
-    npm run --save-dev babelify browserify vinyl-source-stream
-    
+```
+npm install --save-dev babelify browserify vinyl-source-stream
+```
+
 2. Configure ESLint by adding the following block under `eslintConfig` in `package.json`.
 
 ```


### PR DESCRIPTION
Fixed a typo mistake in docs/recipes 

Edit: I don't have an idea why checks have failed on editing a `markdown` file. Did I made any mistake?