### PR TITLE
fixed #188 by removing node v0.10 and v0.12 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,3 @@ language: node_js
 node_js:
   - 'stable'
   - '4'
-  - '0.12'
-  - '0.10'


### PR DESCRIPTION
Fix for #188. Removed node `v0.10` and `v0.12` from travis-ci config. Node already dropped the support of these versions.