### PR TITLE
Add live-reload watch instruction

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,9 @@ Watch task helps you reduce your efforts during development extensions. If the t
 gulp watch
 ```
 
-In order for Live-reload to work, reload extension manually after starting `gulp watch`.
+You need to load/reload extension after starting `gulp watch` for Live-reload to work. 
+
+For content scripts you need to refresh pages where it is used.
 
 ### Build and Package
 

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,8 @@ Watch task helps you reduce your efforts during development extensions. If the t
 gulp watch
 ```
 
+In order for Live-reload to work, reload extension manually after starting `gulp watch`.
+
 ### Build and Package
 
 It will build your app as a result you can have a distribution version of the app in `dist`. Run this command to build your Chrome Extension app.


### PR DESCRIPTION
When extension is loaded and cannot connect to live-reload it will not retry to connect, so watch needs to be running before extension is loaded, so initial manual reload is required.