### PR TITLE
Bump gulp-eslint to work with used babel-eslint

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -16,7 +16,7 @@
     "gulp-cache": "^0.4.3",
     "gulp-chrome-manifest": "0.0.13",
     "gulp-clean-css": "^2.0.3",
-    "gulp-eslint": "^2.0.0",
+    "gulp-eslint": "^6.0.0",
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^2.4.0",
     "gulp-livereload": "^3.8.1",


### PR DESCRIPTION
`gulp lint` fails with `Parsing error: Cannot find module 'eslint-scope' from '/usr/src/extension/node_modules/eslint/lib/api.js'`

This is because `babel-eslint@^10.0.1` (introduced at pull request #209) requires newer `eslint` than the one installed by `gulp-eslint`, which is clearly stated during `npm install` stage:

`npm WARN babel-eslint@10.0.3 requires a peer of eslint@>= 4.12.1 but none is installed. You must install peer dependencies yourself.`

This pull request updates `gulp-eslint` to the latest v6.0.0, which has `eslint@^6.0.0` as dependency, thus satisfying `babel-eslint` peer dependency requirement.