### PR TITLE
Release 0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,20 +15,20 @@
     "test": "mocha --reporter spec --timeout 5000"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.2.5",
+    "@babel/polyfill": "^7.6.0",
     "chrome-manifest": "^0.2.9",
     "generator-jasmine": "^0.2.2",
     "generator-mocha": "^0.3.1",
     "headerize": "^0.1.1",
     "mkdirp": "^0.5.1",
-    "underscore.string": "^3.2.1",
+    "underscore.string": "^3.3.5",
     "yeoman-generator": "^0.24.1"
   },
   "devDependencies": {
     "mocha": "*",
-    "object-assign": "^4.1.0",
-    "yeoman-assert": "^2.2.1",
-    "yeoman-test": "^1.4.0"
+    "object-assign": "^4.1.1",
+    "yeoman-assert": "^2.2.3",
+    "yeoman-test": "^1.9.1"
   },
   "engines": {
     "node": ">=4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-chrome-extension",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Scaffold out a Chrome extension",
   "keywords": [
     "yeoman-generator",


### PR DESCRIPTION
### Changelog for 0.7.3
- 72377be @babel/polyfill: 7.2.5  →  ^7.6.0 
- 72377be underscore.string: ^3.2.1  →  ^3.3.5 
- 72377be object-assign:  ^4.1.0  →  ^4.1.1 
- 72377be yeoman-assert: ^2.2.1  →  ^2.2.3
- 72377be yeoman-test: ^1.4.0  →  ^1.9.1
- 3304eef gulp-eslint: ^2.0.0  →  ^6.0.0
- 72f94e2 upgraded package to version 0.7.3

### Pending
- [x] [Create a release](https://github.com/yeoman/generator-chrome-extension/releases/tag/v0.7.3)
- [x] This PR closes #216 #214
- [ ] release `generator-chrome-extension@0.7.3` in NPM
