### PR TITLE
Tests migrated to ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "object-assign": "^4.1.0",
     "yeoman-assert": "^2.2.1",
     "yeoman-test": "^1.4.0"
   },

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,15 +1,14 @@
-var path = require('path');
-var helpers = require('yeoman-test');
-var assign = require('object-assign');
+const path = require('path');
+const helpers = require('yeoman-test');
 
 module.exports = {
-  run: function (options, prompts, done) {
+  run: (options, prompts, done) => {
     helpers.run(path.join(__dirname, '../app'))
-      .withOptions(assign({
+      .withOptions(Object.assign({
         'skip-install': true,
         'babel': true
       }, options))
-      .withPrompts(assign({
+      .withPrompts(Object.assign({
         'name': 'temp',
         'description': 'description',
         'uiFeatures': [],

--- a/test/test-extension.js
+++ b/test/test-extension.js
@@ -1,15 +1,15 @@
 /*global describe, it */
 'use strict';
 
-var assert = require('yeoman-assert');
-var helper = require('./helper');
+const assert = require('yeoman-assert');
+const helper = require('./helper');
 
-describe('Extension test', function () {
-  it('creates expected files in no UI Action', function (done) {
+describe('Extension test', () => {
+  it('creates expected files in no UI Action', (done) => {
     helper.run({}, {
       'uiAction': 'No'
-    }, function () {
-      var expected = [
+    }, () => {
+      const expected = [
         'app/bower_components',
         'app/manifest.json',
         'app/_locales/en/messages.json',
@@ -26,11 +26,11 @@ describe('Extension test', function () {
     });
   });
 
-  it('creates expected files in Browser Action', function (done) {
+  it('creates expected files in Browser Action', (done) => {
     helper.run({}, {
       'uiAction': 'browserAction'
-    }, function () {
-      var expected = [
+    }, () => {
+      const expected = [
         'app/bower_components',
         'app/scripts.babel/popup.js',
         'app/popup.html'
@@ -45,11 +45,11 @@ describe('Extension test', function () {
     });
   });
 
-  it('creates expected files in Page Action', function (done) {
+  it('creates expected files in Page Action', (done) => {
     helper.run({}, {
       'uiAction': 'pageAction'
-    }, function () {
-      var expected = [
+    }, () => {
+      const expected = [
         'app/bower_components',
         'app/scripts.babel/popup.js',
         'app/popup.html'
@@ -64,11 +64,11 @@ describe('Extension test', function () {
     });
   });
 
-  it('creates expected files with Options Page', function (done) {
+  it('creates expected files with Options Page', (done) => {
     helper.run({}, {
       'uiFeatures': ['optionsUI']
-    }, function () {
-      var expected = [
+    }, () => {
+      const expected = [
         'app/scripts.babel/options.js',
         'app/options.html'
       ];
@@ -83,10 +83,10 @@ describe('Extension test', function () {
     });
   });
 
-  it('creates manifest.json with Omnibox option', function (done) {
+  it('creates manifest.json with Omnibox option', (done) => {
     helper.run({}, {
       'uiFeatures': ['omnibox']
-    }, function () {
+    }, () => {
       assert.fileContent([
         ['app/manifest.json', /"omnibox": {\s+"keyword": "OMNIBOX-KEYWORD"\s+}/]
       ]);
@@ -94,10 +94,10 @@ describe('Extension test', function () {
     });
   });
 
-  it('creates expected files with Content-script option', function (done) {
+  it('creates expected files with Content-script option', (done) => {
     helper.run({}, {
       'uiFeatures': ['contentScripts']
-    }, function () {
+    }, () => {
       assert.fileContent([
         ['app/manifest.json', /"content_scripts": \[\s+{\s+"matches": \[\s+"http:\/\/\*\/\*",\s+"https:\/\/\*\/\*"\s+\],\s+"js": \[\s+"scripts\/contentscript.js"\s+\],\s+"run_at": "document_end",\s+"all_frames": false/],
       ]);
@@ -105,7 +105,7 @@ describe('Extension test', function () {
     });
   });
 
-  it('creates expected manifest permission properties', function (done) {
+  it('creates expected manifest permission properties', (done) => {
     helper.run({}, {
       'permissions': [
         'permission',
@@ -117,7 +117,7 @@ describe('Extension test', function () {
         'http://*/*',
         'https://*/*'
       ]
-    }, function () {
+    }, () => {
       assert.fileContent([
         ['app/manifest.json', /"permissions"/],
         ['app/manifest.json', /"tabs"/],

--- a/test/test-generator.js
+++ b/test/test-generator.js
@@ -1,19 +1,14 @@
 /*global describe, it */
 'use strict';
 
-var assert = require('yeoman-assert');
-var helper = require('./helper');
+const assert = require('yeoman-assert');
+const helper = require('./helper');
 
-function pkgContainsDevDependencies(dependency) {
-  var pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
-  return pkg.devDependencies[dependency] !== undefined;
-}
-
-describe('Generator test', function () {
-  it('creates configuration files', function (done) {
+describe('Generator test', () => {
+  it('creates configuration files', (done) => {
     helper.run({}, {
       'uiAction': 'No'
-    }, function () {
+    }, () => {
       assert.file([
         '.editorconfig',
         '.bowerrc',
@@ -34,10 +29,10 @@ describe('Generator test', function () {
     });
   });
 
-  it('creates expected files with babel', function (done) {
+  it('creates expected files with babel', (done) => {
     helper.run({}, {
       'uiAction': 'No'
-    }, function () {
+    }, () => {
       assert.file([
         'app/manifest.json',
         'app/scripts.babel/background.js',
@@ -56,12 +51,12 @@ describe('Generator test', function () {
     });
   });
 
-  it('creates expected files with --no-babel', function (done) {
+  it('creates expected files with --no-babel', (done) => {
     helper.run({
       babel: false
     }, {
       'uiAction': 'No'
-    }, function () {
+    }, () => {
       assert.file([
         'app/scripts/background.js',
         'app/scripts/chromereload.js',
@@ -81,12 +76,12 @@ describe('Generator test', function () {
     });
   });
 
-  it('creates expected files with sass', function (done) {
+  it('creates expected files with sass', (done) => {
     helper.run({
       sass: true
     }, {
       'uiAction': 'browserAction'
-    }, function () {
+    }, () => {
       assert.file([
         'app/styles.scss/main.scss',
       ]);

--- a/test/test-manifest.js
+++ b/test/test-manifest.js
@@ -1,34 +1,29 @@
 /*global describe, it */
 'use strict';
 
-var assert = require('yeoman-assert');
-var chromeManifest = require('../app/chrome-manifest');
-var headerize = require('headerize');
+const assert = require('yeoman-assert');
+const chromeManifest = require('../app/chrome-manifest');
+const headerize = require('headerize');
 
-function testChoices(choices) {
-  var count = 0;
-  choices.forEach(function (c) {
-    count++;
-    assert.equal(headerize(c.value), c.name);
+const testChoices = (choices) => {
+  choices.forEach((choice) => {
+    assert.equal(headerize(choice.value), choice.name);
   });
-
-  assert.equal(count, choices.length);
 }
 
-describe('Choices test', function () {
-  it('generates the permision list of chrome extension', function (done) {
+describe('Choices test', () => {
+  it('generates the permision list of chrome extension', () => {
       testChoices(chromeManifest.permissionChoices());
       testChoices(chromeManifest.permissionChoices(true));
       testChoices(chromeManifest.uiActionChoices());
       testChoices(chromeManifest.uiFeatureChoices());
 
-      done();
   });
 });
 
-describe('Manifest test', function () {
-  it('generates the permision list of chrome primary', function (done) {
-    var manifest = chromeManifest.createManifest({
+describe('Manifest test', () => {
+  it('generates the permision list of chrome primary', () => {
+    const manifest = chromeManifest.createManifest({
       fields: chromeManifest.uiActions.slice(1).concat(chromeManifest.uiFeatures),
       permissions: chromeManifest.primaryPermissions
     });
@@ -48,7 +43,5 @@ describe('Manifest test', function () {
     assert.ok(manifest.content_scripts);
     assert.ok(manifest.omnibox);
     assert.ok(manifest.web_accessible_resources);
-
-    done();
   });
 });


### PR DESCRIPTION
### Main changes
- Migrated test code base to ES6
- Reduced redundancy
- Removed unused dependencies

### Context
Related to #218 

### Changelog
- 582e731 WIP.Test refactor by @KoolTheba
    - ES6 refactor for `test-manifest`
    - Removed unused callbacks in test
    - Reduced test redundancy
- 857ccb6 WIP.Test refactor by @KoolTheba
    - ES6 refactor for `test-generator`
    - `pkgContainsDevDependencies` has been removed
- 135585d WIP.Test refactor by @KoolTheba
- fc2fee0 Test refactor by @KoolTheba
    - ES6 refactor for `helper`
    - Removed dependency `object-assign`
