### PR TITLE
Listen / build html on changes.

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -106,7 +106,8 @@ gulp.task('babel', () => {
 <% } %>
 gulp.task('clean', del.bind(null, ['.tmp', 'dist']));
 
-gulp.task('watch', ['lint'<% if (babel) { %>, 'babel'<% } %><% if (sass) { %>, 'styles'<% } %>], () => {
+gulp.task('watch', ['lint'<% if (babel) { %>, 'babel'<% } %><% if (sass) { %>, 'styles'<% } %>, 'html'], () => {
+
   $.livereload.listen();
 
   gulp.watch([


### PR DESCRIPTION
# Changes
* The Watch task is listening to html file changes
* The `html` task needs to be run in order for those changes to be live in the via the reload.
* This change adds the `html` task to the `watch` command.

Correct me if I'm wrong, but I think when the html files change the `html` task needs to run to update the html files in the `dist` folder.